### PR TITLE
Feature/automation de bianca

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+
+venv/

--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,16 @@
 # Makefile - Proyecto 13
 
+SHELL := /usr/bin/env bash
+
 # Variables
 SRC=src/main.sh
 OUT_DIR=out
 DIST_DIR=dist
+TEST_DIR ?= tests
 
 .PHONY: tools build run test clean help
 
-# tools: valida las dependencias.
+
 tools:
 	@echo "==> Verificando dependencias..."
 	@command -v curl >/dev/null 2>&1 || { echo "Error: falta 'curl'"; exit 1; }
@@ -16,30 +19,32 @@ tools:
 	@command -v bats >/dev/null 2>&1 || { echo "Error: falta 'bats'"; exit 1; }
 	@echo "Todas las dependencias están disponibles."
 
-# build: crea los directorios out/ y dist/ si no estan creados.
+
 build:
 	@echo "==> Preparando directorios..."
 	mkdir -p $(OUT_DIR) $(DIST_DIR)
 	@echo "Build completado." | tee $(OUT_DIR)/build.log
 	@echo "Evidencia generada en: $(OUT_DIR)/build.log"
 
-# run: usa bash para ejecutar el script
+
 run:
 	@echo "==> Ejecutando flujo principal..."
 	@bash $(SRC) || { echo "Ejecución falló"; exit 1; }
 
-# test: ejecuta pruebas automatizadas
+
 test:
 	@echo "==> Ejecutando pruebas con Bats..."
-	bats tests/
 
-# clean: elimina los archivos creados out/ y dist/
+	@set -o pipefail; bats -r $(TEST_DIR) --formatter pretty | tee out/test-result-s1.log
+	
+
+
 clean:
 	@echo "==> Limpiando..."
 	rm -rf $(OUT_DIR) $(DIST_DIR)
 	@echo "Limpieza completada."
 
-# help: lista los targets y sus descripciones
+
 help:
 	@echo "Targets disponibles:"
 	@echo "  make tools   -> valida dependencias (curl, awk, sed, bats)"

--- a/docs/bitacora-sprint-1.md
+++ b/docs/bitacora-sprint-1.md
@@ -138,3 +138,138 @@ Caso 2: **exito**, establecemos la siguiente configuracion `URL="https://httpbin
 2025-09-25 23:04:16 Inicio de evaluación: URL=https://httpbin.org/status/200, MAX_RETRIES=3, BACKOFF_MS=400ms, JITTER=20%
 2025-09-25 23:04:17 Intento 1: HTTP=200 (timeout=3s)
 ```
+
+
+
+
+## Métricas exportadas
+Al finalizar:
+- Calcula la **latencia total** (`LATENCY_MS`) y el número real de **reintentos** realizados.
+- Escribe una línea en `out/metricas.csv` con: endpoint latencia_ms reintentos estado_final
+**Contenido de cada columna:**
+
+- **endpoint**: URL objetivo utilizada en la prueba.  
+- **latencia_ms**: tiempo total transcurrido desde el inicio de la primera petición (`START_MS`) hasta el final del proceso (`END_MS`), expresado en milisegundos. Esta métrica refleja el impacto de los reintentos y permite evaluar el costo temporal de la estrategia de backoff.  
+- **reintentos**: número real de intentos adicionales realizados antes de obtener una respuesta satisfactoria o de agotar el máximo permitido (`MAX_RETRIES`). Un valor alto puede indicar un endpoint poco confiable.  
+- **estado_final**: resultado global de la ejecución:
+  - `OK` → se alcanzó una respuesta exitosa dentro de los reintentos permitidos.
+  - `FAIL` → se agotaron los reintentos sin obtener éxito.
+
+Cada nueva ejecución del script agrega una línea al CSV, lo que permite ir construyendo un **histórico de pruebas**.  
+Este histórico puede exportarse a otras herramientas (por ejemplo, para graficar en hojas de cálculo) y sirve de base para:
+- **Analizar tendencias de disponibilidad** de distintos endpoints a lo largo del tiempo.
+- **Detectar falsos positivos** en escenarios de alta variabilidad de red.
+- Evaluar el **rendimiento de la política de backoff** (impacto de los parámetros `BACKOFF_MS` y `JITTER_PCT`).
+
+El código de salida del script complementa estas métricas:
+- `0` → reintento exitoso.
+- `1` → fallo tras agotar reintentos.
+
+---
+#### Ejecución
+
+Para las buenas prácticas:
+
+```
+make run
+```
+
+
+#### Evidencias 
+
+En la consola:
+
+```
+bianca007@MSI:/mnt/c/Users/Bianca/Documents/PC2-grupo2-proyecto13$ make run
+==> Ejecutando flujo principal...
+```
+
+
+
+Dentro de `log-intentos.txt` :
+
+2025-09-27 10:54:25 Inicio de evaluación: URL=http://localhost:8080, MAX_RETRIES=3, BACKOFF_MS=500ms, JITTER=20%
+2025-09-27 10:54:25 Intento 1: HTTP=500 (timeout=3s)
+2025-09-27 10:54:25 Reintento programado en 444 ms (±20%). Durmiendo 0.444s…
+2025-09-27 10:54:25 Intento 2: HTTP=200 (timeout=3s)
+2025-09-27 10:54:25 Éxito en intento 2.
+
+
+
+
+
+Dentro de `out/metricas.csv`:
+
+```
+endpoint	latencia_ms	reintentos	estado_final
+http://localhost:9999	3698	3	FAIL
+http://localhost:8080	706	1	OK
+```
+
+### **Pruebas automatizadas: `tests/test_reintentos.bats`**
+
+Se utilizó **Bats (Bash Automated Testing System)** bajo el enfoque **AAA/RGR** (*Arrange-Act-Assert / Red-Green-Refactor*).
+
+#### Casos de prueba
+
+- **Caso rojo: endpoint que siempre falla**  
+- Ejecuta `src/main.sh` apuntando a un puerto cerrado (`http://localhost:9999`).  
+- Se espera que el script termine con un código distinto de `0`.  
+- Demuestra el comportamiento ante fallos permanentes.
+
+- **Caso verde: endpoint que falla una vez y luego responde**  
+- Lanza un pequeño servidor Python “flaky” que:
+  1. En el primer request devuelve HTTP 500 (falla simulada).
+  2. En el segundo request responde HTTP 200 con “OK”.
+- El script debe **reintentar automáticamente** y finalizar con código `0`.
+
+---
+
+### **Integración con Makefile**
+
+Se añadió un target `test`:
+
+```make
+test:
+  @echo "==> Ejecutando pruebas con Bats..."
+  @set -o pipefail; bats -r $(TEST_DIR) --formatter pretty | tee out/test-result-s1.log
+```
+
+#### Ejecucion:
+
+```
+make test
+```
+
+#### Evidencias
+Se crea un archivo dentro de out/log-intentos.txt con las siguientes descripciones y se ve que los 2 tests efectivamente pasan:
+
+```
+test_reintentos.bats
+   Caso rojo: endpoint que siempre falla                                1/2
+ ✓ Caso rojo: endpoint que siempre falla
+   Caso verde: endpoint falla 1 vez y luego responde                  2/2
+ ✓ Caso verde: endpoint falla 1 vez y luego responde
+
+2 tests, 0 failures
+```
+
+
+
+
+En la consola:
+
+
+```
+bianca007@MSI:/mnt/c/Users/Bianca/Documents/PC2-grupo2-proyecto13$ make test
+==> Ejecutando pruebas con Bats...
+test_reintentos.bats
+ ✓ Caso rojo: endpoint que siempre falla
+ ✓ Caso verde: endpoint falla 1 vez y luego responde
+
+2 tests, 0 failures
+```
+
+
+
+

--- a/src/main.sh
+++ b/src/main.sh
@@ -1,10 +1,12 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+
 # Proyecto 13 - Sprint 1
 
-# -------- Config por entorno (12-Factor III) --------
-URL="${URL:-https://example.com}"   # Endpoint objetivo
+
+# - Config por entorno (12-Factor III) 
+URL="${1:-${URL:-https://example.com}}"     # Endpoint objetivo
 MAX_RETRIES="${MAX_RETRIES:-3}"     # Número de reintentos (no incluye el intento inicial)
 BACKOFF_MS="${BACKOFF_MS:-500}"     # Retardo base en milisegundos
 JITTER_PCT="${JITTER_PCT:-20}"      # Porcentaje de jitter (+/-)
@@ -12,7 +14,7 @@ TIMEOUT_S="${TIMEOUT_S:-3}"         # Tiempo máx por request (segundos)
 OUT_DIR="${OUT_DIR:-out}"           # Directorio de evidencias
 LOG_FILE="${LOG_FILE:-$OUT_DIR/log-intentos.txt}"
 
-# -------- Utilidades --------
+#  Utilidades 
 now() { date '+%Y-%m-%d %H:%M:%S'; }
 
 # Calcula retardo (ms) = BACKOFF_MS * 2^(k-1) +/- jitter
@@ -21,14 +23,14 @@ calc_delay_ms(){
     local k="$1"
     local base_ms=$(( BACKOFF_MS * (2 ** (k-1)) ))  
     local jr=$(( base_ms * JITTER_PCT / 100 ))
-  if (( jr > 0 )); then
-    # RANDOM ∈ [0,32767] → mapear a [-jr, +jr]
-    local span=$(( 2*jr + 1 ))
-    local off=$(( RANDOM % span - jr ))
-    echo $(( base_ms + off ))
-  else
-    echo "$base_ms"
-  fi
+    if (( jr > 0 )); then
+        # RANDOM ∈ [0,32767] → mapear a [-jr, +jr]
+        local span=$(( 2*jr + 1 ))
+        local off=$(( RANDOM % span - jr ))
+        echo $(( base_ms + off ))
+    else
+        echo "$base_ms"
+    fi
 }
 
 # Asegura directorio de salida
@@ -37,27 +39,50 @@ mkdir -p "$OUT_DIR"
 : > "$LOG_FILE"
 
 log() {
-  # Imprime en consola y guarda en log
-  # (Usamos tee -a de forma segura)
-  printf "%s %s\n" "$(now)" "$*" | tee -a "$LOG_FILE"
+  printf "%s %s\n" "$(now)" "$*" | tee -a "$LOG_FILE" >/dev/null
 }
 
-# -------- Flujo principal --------
+#  Flujo principal con métricas 
+START_MS=$(date +%s%3N)   # Marca de inicio
+success=0
+
 log "Inicio de evaluación: URL=$URL, MAX_RETRIES=$MAX_RETRIES, BACKOFF_MS=${BACKOFF_MS}ms, JITTER=${JITTER_PCT}%"
 
 for attempt in $(seq 1 $((MAX_RETRIES + 1))); do
-  # Ejecuta request (solo código HTTP; si falla, 000)
   http_code="$(curl -sS -o /dev/null -w '%{http_code}' --max-time "$TIMEOUT_S" "$URL" || echo '000')"
   log "Intento ${attempt}: HTTP=$http_code (timeout=${TIMEOUT_S}s)"
-  if echo "$http_code" | grep -q '^2..$'; then exit 0; fi
-  # si no es el último intento, duerme con backoff:
+  if echo "$http_code" | grep -q '^2..$'; then
+    success=1
+    break
+  fi
   if (( attempt < MAX_RETRIES + 1 )); then
-    k=$attempt
-    delay_ms="$(calc_delay_ms "$k")"
+    delay_ms="$(calc_delay_ms "$attempt")"
     delay_s="$(awk -v ms="$delay_ms" 'BEGIN{printf "%.3f", ms/1000}')"
     log "Reintento programado en ${delay_ms} ms (±${JITTER_PCT}%). Durmiendo ${delay_s}s…"
     sleep "$delay_s"
   fi
 done
-log "Fallo final: agotados ${MAX_RETRIES} reintentos."
-exit 1
+
+if [[ $success -eq 1 ]]; then
+  log "Éxito en intento ${attempt}."
+else
+  log "Fallo final: agotados ${MAX_RETRIES} reintentos."
+fi
+
+END_MS=$(date +%s%3N)   # Marca de fin
+
+#  Métricas 
+LATENCY_MS=$((END_MS - START_MS))
+RETRIES=$((attempt - 1))
+STATE="FAIL"
+[[ $success -eq 1 ]] && STATE="OK"
+
+METRICS_FILE="$OUT_DIR/metricas.csv"
+if [[ ! -f "$METRICS_FILE" ]]; then
+    echo -e "endpoint\tlatencia_ms\treintentos\testado_final" > "$METRICS_FILE"
+fi
+echo -e "$URL\t$LATENCY_MS\t$RETRIES\t$STATE" >> "$METRICS_FILE"
+
+#  Salida final 
+[[ $success -eq 1 ]] && exit 0 || exit 1
+

--- a/tests/test_reintentos.bats
+++ b/tests/test_reintentos.bats
@@ -1,0 +1,40 @@
+#!/usr/bin/env bats
+
+setup() {
+  # Carpeta de salida para logs/CSV si no existe
+  mkdir -p out
+}
+
+@test "Caso rojo: endpoint que siempre falla" {
+  run src/main.sh http://localhost:9999   # puerto cerrado
+  [ "$status" -ne 0 ]                     # Debe fallar
+}
+
+@test "Caso verde: endpoint falla 1 vez y luego responde" {
+  # --- Servidor Python "flaky": 1er request = 500, luego 200 ---
+  python3 - <<'EOF' &
+from http.server import BaseHTTPRequestHandler, HTTPServer
+attempts = {'count': 0}
+
+class Handler(BaseHTTPRequestHandler):
+    def do_GET(self):
+        if attempts['count'] == 0:
+            attempts['count'] += 1
+            self.send_error(500, "Simulated failure")   # Primera vez falla
+        else:
+            self.send_response(200)                    # Luego responde OK
+            self.end_headers()
+            self.wfile.write(b"OK")
+
+HTTPServer(("localhost", 8080), Handler).serve_forever()
+EOF
+  server_pid=$!
+  sleep 1   # da tiempo a levantar el server
+
+  run src/main.sh http://localhost:8080
+
+  kill $server_pid
+  wait $server_pid 2>/dev/null || true
+
+  [ "$status" -eq 0 ]     # Debe terminar en éxito tras reintento
+}


### PR DESCRIPTION
## Qué  
Implementación del script principal `src/main.sh` con **reintentos con backoff exponencial y jitter**, registro de **métricas de latencia y reintentos**, y creación de pruebas automatizadas con **Bats**, integradas en el `Makefile`.

## Por qué  
- Validar la **resiliencia de endpoints** midiendo latencia y número real de reintentos.  
- Mantener un **histórico de métricas** en `out/metricas.csv` para evaluar disponibilidad y tendencias en el tiempo.  
- Asegurar, mediante **pruebas BDD**, que la política de reintentos funciona correctamente ante fallos transitorios.  
- Integrar las pruebas en el **flujo de CI/CD** a través del target `make test`.

## Cómo  
- **Extensión del script `src/main.sh`:**  
  - Calcula y exporta **latencia total**, número de reintentos y estado final (`OK` o `FAIL`) en `out/metricas.csv`.  
  - Registra cada intento en `out/log-intentos.txt` para trazabilidad.

- **Pruebas automatizadas con Bats (`tests/test_reintentos.bats`):**  
  - **Caso rojo:** endpoint que siempre falla (espera código de salida distinto de `0`).  
  - **Caso verde:** endpoint que falla una vez y luego responde (espera código de salida `0`).

- **Integración en `Makefile`:**  
  - Nuevo target `test` que ejecuta los tests Bats en modo recursivo.  
  - Exporta el resultado en `out/test-result-s1.log` para auditoría.

- **Evidencias:**  
  - Consola y archivos en `out/` demuestran el correcto registro de métricas y el paso de todos los tests.
