### PR TITLE
Feature/politicas metodo/bianca

### DIFF
--- a/docs/bitacora-sprint2.md
+++ b/docs/bitacora-sprint2.md
@@ -1,0 +1,118 @@
+#  Sprint 2 – Políticas por método e idempotencia  
+
+## 1. Descripción del problema
+En este sprint se definió la política de **reintentos diferenciada por método HTTP**, considerando el criterio de idempotencia:  
+
+- **GET y PUT**: reintentos permitidos libremente.  
+- **POST**: bloqueados por defecto, debido al riesgo de duplicar efectos en operaciones no idempotentes.  
+- **POST con `--allow-post-retries`**: se habilitan los reintentos únicamente con este flag para escenarios de prueba controlados.  
+
+---
+
+## 2. Implementación en `src/main.sh`
+- Se agregó un **bloque condicional** que detecta el método HTTP (`GET`, `PUT`, `POST`).  
+- La lógica de reintentos quedó así:
+  - `GET` y `PUT`: utilizan la política de reintentos ya existente (backoff exponencial + jitter).  
+  - `POST`: por defecto ejecuta **un solo intento**.  
+  - `POST --allow-post-retries`: habilita el ciclo de reintentos, aplicando el mismo algoritmo que GET/PUT.  
+- Se añadió **registro detallado en logs** para indicar la política aplicada (ej. “Política: POST con flag --allow-post-retries → reintentos habilitados”).  
+- Se mantiene compatibilidad con las métricas (`metrics.csv`) y los archivos de salida en `out/`.  
+
+---
+
+## 3. Ejecucion
+```bash
+
+Desde la raiz del proyecto:
+
+# GET → reintentos habilitados por defecto
+./src/main.sh GET https://example.com
+
+# PUT → reintentos habilitados por defecto
+./src/main.sh PUT https://example.com/resource
+
+# POST → bloquea reintentos, solo intenta una vez
+./src/main.sh POST https://example.com
+
+# POST con flag → habilita reintentos
+./src/main.sh POST https://example.com --allow-post-retries
+```
+
+## Archivos generados
+
+En out/out.log : registro detallado de ejecución, incluyendo políticas aplicadas, intentos, latencias y estados.
+
+En out/metrics.csv : tabla acumulada de métricas con los campos, que ahora se le agrego la columna `method`
+
+```
+method, endpoint, latencia_ms, reintentos, estado_final
+```
+
+## Ejemplos de salida:
+
+En out/metricas.csv se tiene ahora:
+
+```
+GET	https://example.com	2889	0	OK
+PUT	https://example.com/resource	13340	3	FAIL
+POST	https://example.com	2679	0	FAIL
+POST	https://example.com	12780	3	FAIL
+```
+
+## En la consola :
+```
+bianca007@MSI:/mnt/c/Users/Bianca/Documents/PC2-grupo2-proyecto13$ ./src/main.sh GET https://example.com
+bianca007@MSI:/mnt/c/Users/Bianca/Documents/PC2-grupo2-proyecto13$ ./src/main.sh PUT https://example.com
+bianca007@MSI:/mnt/c/Users/Bianca/Documents/PC2-grupo2-proyecto13$ ./src/main.sh POST https://example.com
+bianca007@MSI:/mnt/c/Users/Bianca/Documents/PC2-grupo2-proyecto13$ ./src/main.sh POST https://example.com --allow-post-retries
+```
+
+## Ejemlos de salida en el out/log-intentos.txt:
+
+
+
+** Para GET  la salida de out/log-intentos-txt:
+
+
+2025-09-30 11:33:42 Política: GET es idempotente → reintentos habilitados (MAX_RETRIES=3).
+2025-09-30 11:33:42 Inicio de evaluación: METHOD=GET, URL=https://example.com, MAX_RETRIES=3, BACKOFF_MS=500ms, JITTER=20%
+2025-09-30 11:33:45 Intento 1: HTTP=200 (timeout=3s)
+2025-09-30 11:33:45 Éxito en intento 1.
+
+** Para PUT:
+
+2025-09-30 11:35:17 Política: PUT es idempotente → reintentos habilitados (MAX_RETRIES=3).
+2025-09-30 11:35:18 Inicio de evaluación: METHOD=PUT, URL=https://example.com/resource, MAX_RETRIES=3, BACKOFF_MS=500ms, JITTER=20%
+2025-09-30 11:35:20 Intento 1: HTTP=501 (timeout=3s)
+2025-09-30 11:35:20 Reintento programado en 479 ms (±20%). Durmiendo 0.479s…
+2025-09-30 11:35:24 Intento 2: HTTP=501 (timeout=3s)
+2025-09-30 11:35:24 Reintento programado en 896 ms (±20%). Durmiendo 0.896s…
+2025-09-30 11:35:27 Intento 3: HTTP=501 (timeout=3s)
+2025-09-30 11:35:27 Reintento programado en 2232 ms (±20%). Durmiendo 2.232s…
+2025-09-30 11:35:32 Intento 4: HTTP=501 (timeout=3s)
+2025-09-30 11:35:32 Fallo final: agotados 4 intentos.
+
+**Para POST, con intentos deshabilitados:
+
+2025-09-30 11:36:55 Política: POST sin flag → reintentos deshabilitados.
+2025-09-30 11:36:55 Inicio de evaluación: METHOD=POST, URL=https://example.com, MAX_RETRIES=3, BACKOFF_MS=500ms, JITTER=20%
+2025-09-30 11:36:57 Intento 1: HTTP=411 (timeout=3s)
+2025-09-30 11:36:57 No se permiten reintentos adicionales para POST. Abortando.
+2025-09-30 11:36:57 Fallo final: agotados 1 intentos.
+
+**Para POST, con intentos habilitados con --allow-post-retries :
+
+2025-09-30 11:38:17 Política: POST con flag --allow-post-retries → reintentos habilitados.
+2025-09-30 11:38:17 Inicio de evaluación: METHOD=POST, URL=https://example.com, MAX_RETRIES=3, BACKOFF_MS=500ms, JITTER=20%
+2025-09-30 11:38:19 Intento 1: HTTP=411 (timeout=3s)
+2025-09-30 11:38:19 Reintento programado en 418 ms (±20%). Durmiendo 0.418s…
+2025-09-30 11:38:23 Intento 2: HTTP=411 (timeout=3s)
+2025-09-30 11:38:23 Reintento programado en 1174 ms (±20%). Durmiendo 1.174s…
+2025-09-30 11:38:26 Intento 3: HTTP=411 (timeout=3s)
+2025-09-30 11:38:26 Reintento programado en 1650 ms (±20%). Durmiendo 1.650s…
+2025-09-30 11:38:30 Intento 4: HTTP=411 (timeout=3s)
+2025-09-30 11:38:30 Fallo final: agotados 4 intentos.
+
+
+
+

--- a/src/main.sh
+++ b/src/main.sh
@@ -1,30 +1,35 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# Proyecto 13 - Sprint 2
+# Reintentos con backoff exponencial + jitter + políticas por método
 
-# Proyecto 13 - Sprint 1
-
-
-# - Config por entorno (12-Factor III) 
-URL="${1:-${URL:-https://example.com}}"     # Endpoint objetivo
-MAX_RETRIES="${MAX_RETRIES:-3}"     # Número de reintentos (no incluye el intento inicial)
-BACKOFF_MS="${BACKOFF_MS:-500}"     # Retardo base en milisegundos
-JITTER_PCT="${JITTER_PCT:-20}"      # Porcentaje de jitter (+/-)
-TIMEOUT_S="${TIMEOUT_S:-3}"         # Tiempo máx por request (segundos)
-OUT_DIR="${OUT_DIR:-out}"           # Directorio de evidencias
+# -------- Config por entorno (12-Factor III) --------
+METHOD="${1:-${METHOD:-GET}}"                # Método HTTP (GET, POST, PUT)
+URL="${2:-${URL:-https://example.com}}"      # Endpoint objetivo
+ALLOW_POST_RETRIES=0                         # Flag por defecto (deshabilitado)
+MAX_RETRIES="${MAX_RETRIES:-3}"              # Número de reintentos (no incluye el intento inicial)
+BACKOFF_MS="${BACKOFF_MS:-500}"              # Retardo base en milisegundos
+JITTER_PCT="${JITTER_PCT:-20}"               # Porcentaje de jitter (+/-)
+TIMEOUT_S="${TIMEOUT_S:-3}"                  # Tiempo máx por request (segundos)
+OUT_DIR="${OUT_DIR:-out}"                    # Directorio de evidencias
 LOG_FILE="${LOG_FILE:-$OUT_DIR/log-intentos.txt}"
 
-#  Utilidades 
+# Procesar argumentos extra (para flag --allow-post-retries)
+for arg in "$@"; do
+  if [[ "$arg" == "--allow-post-retries" ]]; then
+    ALLOW_POST_RETRIES=1
+  fi
+done
+
+# -------- Utilidades --------
 now() { date '+%Y-%m-%d %H:%M:%S'; }
 
-# Calcula retardo (ms) = BACKOFF_MS * 2^(k-1) +/- jitter
-# k es el índice de reintento (1..MAX_RETRIES)
 calc_delay_ms(){
     local k="$1"
     local base_ms=$(( BACKOFF_MS * (2 ** (k-1)) ))  
     local jr=$(( base_ms * JITTER_PCT / 100 ))
     if (( jr > 0 )); then
-        # RANDOM ∈ [0,32767] → mapear a [-jr, +jr]
         local span=$(( 2*jr + 1 ))
         local off=$(( RANDOM % span - jr ))
         echo $(( base_ms + off ))
@@ -33,45 +38,72 @@ calc_delay_ms(){
     fi
 }
 
-# Asegura directorio de salida
 mkdir -p "$OUT_DIR"
-# Limpia/crea log (idempotente)
 : > "$LOG_FILE"
 
 log() {
   printf "%s %s\n" "$(now)" "$*" | tee -a "$LOG_FILE" >/dev/null
 }
 
-#  Flujo principal con métricas 
-START_MS=$(date +%s%3N)   # Marca de inicio
+# -------- Política de idempotencia --------
+case "$METHOD" in
+  GET|PUT)
+    RETRIES_ENABLED=1
+    log "Política: $METHOD es idempotente → reintentos habilitados (MAX_RETRIES=$MAX_RETRIES)."
+    ;;
+  POST)
+    if [[ $ALLOW_POST_RETRIES -eq 1 ]]; then
+      RETRIES_ENABLED=1
+      log "Política: POST con flag --allow-post-retries → reintentos habilitados."
+    else
+      RETRIES_ENABLED=0
+      log "Política: POST sin flag → reintentos deshabilitados."
+    fi
+    ;;
+  *)
+    log "Método $METHOD no reconocido. Abortando."
+    exit 1
+    ;;
+esac
+
+# -------- Flujo principal con métricas --------
+START_MS=$(date +%s%3N)
 success=0
 
-log "Inicio de evaluación: URL=$URL, MAX_RETRIES=$MAX_RETRIES, BACKOFF_MS=${BACKOFF_MS}ms, JITTER=${JITTER_PCT}%"
+log "Inicio de evaluación: METHOD=$METHOD, URL=$URL, MAX_RETRIES=$MAX_RETRIES, BACKOFF_MS=${BACKOFF_MS}ms, JITTER=${JITTER_PCT}%"
 
 for attempt in $(seq 1 $((MAX_RETRIES + 1))); do
-  http_code="$(curl -sS -o /dev/null -w '%{http_code}' --max-time "$TIMEOUT_S" "$URL" || echo '000')"
+  http_code="$(curl -sS -o /dev/null -w '%{http_code}' -X "$METHOD" --max-time "$TIMEOUT_S" "$URL" || echo '000')"
   log "Intento ${attempt}: HTTP=$http_code (timeout=${TIMEOUT_S}s)"
+
   if echo "$http_code" | grep -q '^2..$'; then
     success=1
     break
   fi
+
+  # Control de reintentos según política
   if (( attempt < MAX_RETRIES + 1 )); then
-    delay_ms="$(calc_delay_ms "$attempt")"
-    delay_s="$(awk -v ms="$delay_ms" 'BEGIN{printf "%.3f", ms/1000}')"
-    log "Reintento programado en ${delay_ms} ms (±${JITTER_PCT}%). Durmiendo ${delay_s}s…"
-    sleep "$delay_s"
+    if [[ $RETRIES_ENABLED -eq 1 ]]; then
+      delay_ms="$(calc_delay_ms "$attempt")"
+      delay_s="$(awk -v ms="$delay_ms" 'BEGIN{printf "%.3f", ms/1000}')"
+      log "Reintento programado en ${delay_ms} ms (±${JITTER_PCT}%). Durmiendo ${delay_s}s…"
+      sleep "$delay_s"
+    else
+      log "No se permiten reintentos adicionales para $METHOD. Abortando."
+      break
+    fi
   fi
 done
 
 if [[ $success -eq 1 ]]; then
   log "Éxito en intento ${attempt}."
 else
-  log "Fallo final: agotados ${MAX_RETRIES} reintentos."
+  log "Fallo final: agotados ${attempt} intentos."
 fi
 
-END_MS=$(date +%s%3N)   # Marca de fin
+END_MS=$(date +%s%3N)
 
-#  Métricas 
+# -------- Métricas --------
 LATENCY_MS=$((END_MS - START_MS))
 RETRIES=$((attempt - 1))
 STATE="FAIL"
@@ -79,10 +111,10 @@ STATE="FAIL"
 
 METRICS_FILE="$OUT_DIR/metricas.csv"
 if [[ ! -f "$METRICS_FILE" ]]; then
-    echo -e "endpoint\tlatencia_ms\treintentos\testado_final" > "$METRICS_FILE"
+    echo -e "method\tendpoint\tlatencia_ms\treintentos\testado_final" > "$METRICS_FILE"
 fi
-echo -e "$URL\t$LATENCY_MS\t$RETRIES\t$STATE" >> "$METRICS_FILE"
+echo -e "$METHOD\t$URL\t$LATENCY_MS\t$RETRIES\t$STATE" >> "$METRICS_FILE"
 
-#  Salida final 
 [[ $success -eq 1 ]] && exit 0 || exit 1
+
 


### PR DESCRIPTION
## Qué

Implementamos una política de reintentos diferenciada por método HTTP en el script src/main.sh:

GET y PUT: reintentos permitidos libremente.

POST: reintentos bloqueados por defecto.

POST con --allow-post-retries: permite reintentos solo en pruebas controladas.

Además, se registran en los logs las decisiones de política aplicadas y se mantiene compatibilidad con metrics.csv y archivos de salida en out/.
## Por qué
Se hizo esta diferenciación porque:

* GET y PUT son idempotentes, por lo que repetir la operación no produce efectos secundarios indeseados.

* POST no es idempotente; reintentos automáticos podrían duplicar operaciones (p.ej., creación de registros).

* Se necesitaba controlar pruebas de reintento de POST sin comprometer la integridad de los datos reales.

* Registrar la política aplicada permite trazabilidad y auditoría de la ejecución.
## Cómo

Se implementó en src/main.sh, agregando este bloque condicional por método HTTP:
```
if [[ "$METHOD" == "GET" || "$METHOD" == "PUT" ]]; then
    # Aplicar política estándar de reintentos con backoff exponencial + jitter
elif [[ "$METHOD" == "POST" ]]; then
    if [[ "$ALLOW_POST_RETRIES" == "true" ]]; then
        # Habilitar ciclo de reintentos como GET/PUT
    else
        # Ejecutar solo un intento y registrar en log
    fi
fi

```
Esto cumple con registro en logs y Compatibilidad con métricas y salida.